### PR TITLE
[feature/12-cors] CORS 설정을 위해 WebConfig 구현

### DIFF
--- a/src/main/kotlin/com/goosesdream/golaping/configuration/WebConfig.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/configuration/WebConfig.kt
@@ -1,0 +1,15 @@
+package com.goosesdream.golaping.configuration
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.CorsRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebConfig : WebMvcConfigurer {
+    override fun addCorsMappings(registry: CorsRegistry) {
+        registry.addMapping("/**")
+            .allowedOrigins("http://localhost:3300") //TODO: 프론트 배포 후 주소 추가
+            .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE")
+            .allowCredentials(true) // 쿠키
+    }
+}


### PR DESCRIPTION
## 🪁 관련 이슈
#12

## ✨ 추가/수정/개선된 사항
- WebConfig 구현
  - 추후 세션 쿠키 사용을 위해 allowCredentials 값 true로 설정

## 📢 참고 사항
- 프론트 배포 후 배포주소 추가
