### PR TITLE
[develop] 유저별 웹소켓 채널 관리 구현

### DIFF
--- a/src/main/kotlin/com/goosesdream/golaping/common/websocket/GlobalWebSocketHandler.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/common/websocket/GlobalWebSocketHandler.kt
@@ -7,19 +7,52 @@ import org.springframework.web.socket.WebSocketMessage
 import org.springframework.web.socket.WebSocketSession
 
 @Component
-class GlobalWebSocketHandler : WebSocketHandler {
-
-    private val sessions = mutableMapOf<String, WebSocketSession>()
+class GlobalWebSocketHandler(
+    private val webSocketManager: WebSocketManager
+) : WebSocketHandler{
 
     override fun afterConnectionEstablished(session: WebSocketSession) {
-
         val voteUuid = session.attributes["voteUuid"] as? String
-        val nickname = session.attributes["nickname"] as? String // 투표 종료 상태면 empty string
-        val isVoteEnded = session.attributes["isVoteEnded"] as? Boolean
 
         if (voteUuid != null) {
-            sessions[voteUuid] = session
-            println("New session for vote: $voteUuid, Nickname: $nickname, VoteEnded: $isVoteEnded")
+            var expirationTime = webSocketManager.getChannelExpirationTime(voteUuid)
+
+            if (expirationTime != null) {
+                val remainingTimeMillis = expirationTime - System.currentTimeMillis()
+
+                // 세션이 없으면(처음 접속하는 유저) 새로운 타이머 설정
+                val existingSession = webSocketManager.restoreWebSocketSession(voteUuid)
+                if (existingSession == null) {
+                    if (remainingTimeMillis > 0) {
+                        webSocketManager.setWebSocketTimer(voteUuid, remainingTimeMillis)
+                    } else {
+                        webSocketManager.stopWebSocketForVote(voteUuid)
+                    }
+                }
+            } else { // 이미 종료된 투표 또는 유효하지 않은 상태인 경우
+                webSocketManager.stopWebSocketForVote(voteUuid)
+            }
+
+            // 세션이 없으면(처음 접속하는 유저) 새로운 채널 시작
+            val existingSession = webSocketManager.restoreWebSocketSession(voteUuid)
+            if (existingSession == null) {
+                expirationTime = webSocketManager.getChannelExpirationTime(voteUuid)
+                val timeLimit = expirationTime?.let { // 투표 남은 시간만큼 웹소켓 세션 timeLimit 설정
+                    val remainingTimeMillis = it - System.currentTimeMillis()
+                    if (remainingTimeMillis > 0) {
+                        (remainingTimeMillis / 1000 / 60).toInt()
+                    } else {
+                        return@let null
+                    }
+                }
+
+                if (timeLimit == null) {
+                    webSocketManager.stopWebSocketForVote(voteUuid)
+                } else { // 새로운 채널 시작
+                    webSocketManager.startWebSocketForVote(voteUuid, timeLimit)
+                }
+            }
+            webSocketManager.saveWebSocketSession(voteUuid, session)
         }
     }
 
@@ -30,18 +63,14 @@ class GlobalWebSocketHandler : WebSocketHandler {
     override fun handleTransportError(session: WebSocketSession, exception: Throwable) {
         val voteUuid = session.attributes["voteUuid"] as? String
         if (voteUuid != null) {
-            sessions.remove(voteUuid)
-            println("Transport error for vote: $voteUuid")
+            webSocketManager.stopWebSocketForVote(voteUuid)
         }
-        println("Error occurred: ${exception.message}")
-        exception.printStackTrace()
     }
 
     override fun afterConnectionClosed(session: WebSocketSession, closeStatus: CloseStatus) {
         val voteUuid = session.attributes["voteUuid"] as? String
         if (voteUuid != null) {
-            sessions.remove(voteUuid)
-            println("Session closed for vote: $voteUuid")
+            webSocketManager.stopWebSocketForVote(voteUuid)
         }
     }
 

--- a/src/main/kotlin/com/goosesdream/golaping/common/websocket/WebSocketManager.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/common/websocket/WebSocketManager.kt
@@ -1,19 +1,45 @@
 package com.goosesdream.golaping.common.websocket
 
-import com.goosesdream.golaping.common.base.BaseException
-import com.goosesdream.golaping.common.base.BaseResponseStatus.ALREADY_EXIST_CHANNEL
+import com.goosesdream.golaping.redis.service.RedisService
+import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Service
+import org.springframework.web.socket.WebSocketSession
 import java.util.*
+import java.util.concurrent.TimeUnit
 
 @Service
-class WebSocketManager { // 웹소켓 채널 관리
+class WebSocketManager(
+    private val redisTemplate: RedisTemplate<String, String>,
+    private val redisService: RedisService
+) {
+    private val webSocketTimers = mutableMapOf<String, Timer>() // 타이머 관리
+    private val webSocketSessions = mutableMapOf<String, WebSocketSession>()  // 메모리 내 웹소켓 세션 관리
 
-    private val activeChannels = mutableMapOf<String, Timer>()
+    private val voteExpirationPrefix = "vote:expiration:"
+    private val voteSessionPrefix = "vote:session:"
 
-    // 채널 생성
+    // 투표 UUID에 대한 WebSocket 세션 시작
     fun startWebSocketForVote(voteUuid: String, timeLimit: Int) {
-        if (activeChannels.containsKey(voteUuid)) {
-            throw BaseException(ALREADY_EXIST_CHANNEL)
+        val expirationTime = getChannelExpirationTime(voteUuid)
+
+        if (expirationTime != null) {
+            val remainingTimeMillis = expirationTime - System.currentTimeMillis()
+
+            if (remainingTimeMillis > 0) {
+                // 타이머 설정
+                setWebSocketTimer(voteUuid, remainingTimeMillis)
+            } else { // 이미 만료된 경우 바로 종료 처리
+                stopWebSocketForVote(voteUuid)
+            }
+        } else {
+            stopWebSocketForVote(voteUuid)
+        }
+    }
+
+    // WebSocket 타이머 설정
+    fun setWebSocketTimer(voteUuid: String, remainingTimeMillis: Long) {
+        if (webSocketTimers.containsKey(voteUuid)) {
+            return // 이미 타이머가 설정되어 있으면 중복 생성 방지
         }
 
         val timer = Timer()
@@ -21,14 +47,58 @@ class WebSocketManager { // 웹소켓 채널 관리
             override fun run() {
                 stopWebSocketForVote(voteUuid)
             }
-        }, timeLimit * 60 * 1000L)
+        }, remainingTimeMillis)
 
-        activeChannels[voteUuid] = timer // uuid 형식
+        webSocketTimers[voteUuid] = timer
     }
 
     // 채널 종료
     fun stopWebSocketForVote(voteUuid: String) {
-        activeChannels[voteUuid]?.cancel()
-        activeChannels.remove(voteUuid)
+        redisTemplate.delete(voteUuid)
+
+        // 타이머 취소
+        webSocketTimers[voteUuid]?.cancel()
+        webSocketTimers.remove(voteUuid)
+
+        // WebSocket 세션 종료
+        webSocketSessions.remove(voteUuid)
+    }
+
+
+    // 채널 만료 시간 조회
+    fun getChannelExpirationTime(voteUuid: String): Long? {
+        val redisKey = voteExpirationPrefix + voteUuid
+        val ttlInSeconds = redisTemplate.getExpire(redisKey, TimeUnit.SECONDS)
+
+        return if (ttlInSeconds > 0) {
+            System.currentTimeMillis() + ttlInSeconds * 1000L
+        } else {
+            null
+        }
+    }
+
+    // 세션 복원 (Redis에서 세션 정보 복원)
+    fun restoreWebSocketSession(voteUuid: String): WebSocketSession? {
+        val sessionId = redisService.get(voteSessionPrefix + voteUuid)
+
+        return if (sessionId != null) {
+            webSocketSessions[voteUuid]
+        } else {
+            null
+        }
+    }
+
+    // 세션 저장
+    fun saveWebSocketSession(voteUuid: String, session: WebSocketSession) {
+        val expirationTime = getChannelExpirationTime(voteUuid)
+
+        val ttlInSeconds = expirationTime?.let {
+            (it - System.currentTimeMillis()) / 1000  // 남은 시간을 초 단위로
+        }
+
+        ttlInSeconds?.let {
+            redisService.save(voteSessionPrefix + voteUuid, session.id, it)
+        }
+        webSocketSessions[voteUuid] = session
     }
 }


### PR DESCRIPTION
## 🪁 관련 이슈
#49

## ✨ 추가/수정/개선된 사항
- 재배포 시에도 웹소켓 세션 정보를 기억하기 위해 redis에 웹소켓 세션 저장하도록 구현
- 투표에 처음 접속한 유저의 경우 웹소켓 채널 생성(투표 남은 시간만큼 타이머 등록)

## 📢 참고 사항

