### PR TITLE
[fix/63-createVote] 투표 생성 시 생성자를 새로운 유저로 빌드하도록 수정

### DIFF
--- a/src/main/kotlin/com/goosesdream/golaping/common/base/BaseResponseStatus.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/common/base/BaseResponseStatus.kt
@@ -23,7 +23,7 @@ enum class BaseResponseStatus(
 
     // vote
     INVALID_VOTE_TYPE(false, HttpStatus.BAD_REQUEST, "투표 타입이 올바르지 않습니다."),
-    INVALID_TIME_LIMIT(false, HttpStatus.BAD_REQUEST, "투표 제한 시간이 유효하지 않습니다."),
+    INVALID_TIME_LIMIT(false, HttpStatus.BAD_REQUEST, "투표 제한 시간은 0분보다 커야합니다."),
     ALREADY_EXIST_CHANNEL(false, HttpStatus.BAD_REQUEST, "이미 존재하는 채널입니다."),
 
     // session

--- a/src/main/kotlin/com/goosesdream/golaping/user/service/UserService.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/user/service/UserService.kt
@@ -31,11 +31,8 @@ class UserService(
         return newUser
     }
 
-    fun findOrCreateUser(nickname : String, voteUuid: String): Users {
-        val vote = voteRepository.findByUuid(voteUuid) ?: throw BaseException(INVALID_VOTE_UUID)
-        val participant = participantRepository.findByVoteAndUserNickname(vote, nickname)
-
-        return participant?.user ?: buildAndSaveUser(nickname)
+    fun createUserForVote(nickname: String): Users {
+        return buildAndSaveUser(nickname)
     }
 
     private fun buildAndSaveUser(nickname: String): Users {

--- a/src/main/kotlin/com/goosesdream/golaping/vote/controller/VoteController.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/vote/controller/VoteController.kt
@@ -48,10 +48,11 @@ class VoteController(
 
         val voteUuid = URI(voteRequest.link).path.split("/").last() // uuid 형식
 
+
         voteService.saveVoteExpirationToRedis(voteUuid, voteRequest.timeLimit)
         webSocketManager.startWebSocketForVote(voteUuid, voteRequest.timeLimit)
 
-        val creator = userService.findOrCreateUser(voteRequest.nickname, voteUuid)
+        val creator = userService.createUserForVote(voteRequest.nickname)
         voteService.createVote(voteRequest, voteUuid, creator)
         userService.addParticipant(creator, voteUuid)
 

--- a/src/main/kotlin/com/goosesdream/golaping/vote/service/VoteService.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/vote/service/VoteService.kt
@@ -5,7 +5,6 @@ import com.goosesdream.golaping.common.base.BaseResponseStatus.*
 import com.goosesdream.golaping.common.enums.VoteType
 import com.goosesdream.golaping.redis.service.RedisService
 import com.goosesdream.golaping.user.entity.Users
-import com.goosesdream.golaping.user.repository.UserRepository
 import com.goosesdream.golaping.vote.dto.CreateVoteRequest
 import com.goosesdream.golaping.vote.entity.Votes
 import com.goosesdream.golaping.vote.repository.VoteRepository
@@ -16,12 +15,11 @@ import java.time.LocalDateTime
 @Service
 class VoteService(
     private val voteRepository: VoteRepository,
-    private val userRepository: UserRepository,
     private val redisService: RedisService
 ) {
     // 투표 생성
     @Transactional(rollbackFor = [Exception::class])
-    fun createVote(request: CreateVoteRequest, voteUuid: String, creator: Users) { //TODO: voteType 체크 로직
+    fun createVote(request: CreateVoteRequest, voteUuid: String, creator: Users) { //TODO: voteType에 따라 다른 로직 구현 필요
         val voteType = parseVoteType(request.type)
         validateTimeLimit(request.timeLimit)
 
@@ -50,7 +48,7 @@ class VoteService(
             creator = creator,
             type = voteType,
             endTime = endTime,
-            userVoteLimit = request.userVoteLimit,
+            userVoteLimit = request.userVoteLimit.takeIf { it != 0 },
             link = request.link,
             uuid = voteUuid
         )

--- a/src/test/kotlin/com/goosesdream/golaping/vote/VoteControllerTest.kt
+++ b/src/test/kotlin/com/goosesdream/golaping/vote/VoteControllerTest.kt
@@ -74,7 +74,7 @@ class VoteControllerTest {
         doNothing().`when`(sessionService).saveCreatorNicknameToSession(any(), eq("testUser"), eq(10))
         doNothing().`when`(webSocketManager).startWebSocketForVote(any(), eq(10))
 
-        `when`(userService.findOrCreateUser(eq("testUser"), eq(voteUuid))).thenReturn(creator)
+        `when`(userService.createUserForVote(eq("testUser"))).thenReturn(creator)
         doNothing().`when`(voteService).createVote(any(), eq(sessionId), eq(creator))
 
         val result = mockMvc.perform(
@@ -96,7 +96,7 @@ class VoteControllerTest {
 
         verify(sessionService).saveCreatorNicknameToSession(any(), eq("testUser"), eq(10))
         verify(webSocketManager).startWebSocketForVote(eq(voteUuid), eq(10))
-        verify(userService).findOrCreateUser(eq("testUser"), eq(voteUuid))
+        verify(userService).createUserForVote(eq("testUser"))
         verify(voteService).createVote(eq(voteRequest), eq(voteUuid), eq(creator))
     }
 }


### PR DESCRIPTION
## 🪁 관련 이슈
#63

## ✨ 추가/수정/개선된 사항
- 투표 생성 로직에서 생성자를 DB에서 찾지 않고 반드시 새로운 유저로 생성하도록 수정
- 인당 투표 횟수가 0일 경우 null로 처리

## 📢 참고 사항

