### PR TITLE
[feature/61-webSocketResponse] 웹소켓 응답을 위한 데이터 클래스 구현 및 HTTP 응답과 분리

### DIFF
--- a/src/main/kotlin/com/goosesdream/golaping/common/base/BaseException.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/common/base/BaseException.kt
@@ -1,5 +1,7 @@
 package com.goosesdream.golaping.common.base
 
+import com.goosesdream.golaping.common.enums.BaseResponseStatus
+
 class BaseException(
     val status: BaseResponseStatus
 ) : RuntimeException()

--- a/src/main/kotlin/com/goosesdream/golaping/common/base/BaseResponse.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/common/base/BaseResponse.kt
@@ -3,7 +3,8 @@ package com.goosesdream.golaping.common.base
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonPropertyOrder
-import com.goosesdream.golaping.common.base.BaseResponseStatus.SUCCESS
+import com.goosesdream.golaping.common.enums.BaseResponseStatus
+import com.goosesdream.golaping.common.enums.BaseResponseStatus.SUCCESS
 
 @JsonPropertyOrder("isSuccess", "message", "result")
 data class BaseResponse<T>(
@@ -14,6 +15,12 @@ data class BaseResponse<T>(
     @JsonInclude(JsonInclude.Include.NON_NULL)
     val result: T? = null
 ) {
+
+    constructor() : this(
+        isSuccess = true,
+        message = SUCCESS.message,
+        result = null
+    )
 
     constructor(result: T) : this(
         isSuccess = SUCCESS.isSuccess,

--- a/src/main/kotlin/com/goosesdream/golaping/common/enums/BaseResponseStatus.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/common/enums/BaseResponseStatus.kt
@@ -1,4 +1,4 @@
-package com.goosesdream.golaping.common.base
+package com.goosesdream.golaping.common.enums
 
 import org.springframework.http.HttpStatus
 

--- a/src/main/kotlin/com/goosesdream/golaping/common/enums/BaseResponseStatus.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/common/enums/BaseResponseStatus.kt
@@ -25,6 +25,7 @@ enum class BaseResponseStatus(
     INVALID_VOTE_TYPE(false, HttpStatus.BAD_REQUEST, "투표 타입이 올바르지 않습니다."),
     INVALID_TIME_LIMIT(false, HttpStatus.BAD_REQUEST, "투표 제한 시간은 0분보다 커야합니다."),
     ALREADY_EXIST_CHANNEL(false, HttpStatus.BAD_REQUEST, "이미 존재하는 채널입니다."),
+    VOTE_NOT_FOUND(false, HttpStatus.BAD_REQUEST, "존재하지 않는 투표입니다."),
 
     // session
     INVALID_SESSION(false, HttpStatus.BAD_REQUEST, "유효하지 않은 세션입니다."),

--- a/src/main/kotlin/com/goosesdream/golaping/common/enums/WebSocketResponseStatus.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/common/enums/WebSocketResponseStatus.kt
@@ -1,0 +1,22 @@
+package com.goosesdream.golaping.common.enums
+
+enum class WebSocketResponseStatus(
+    val isSuccess: Boolean,
+    val code: String,
+    val message: String
+) {
+
+    /**
+     * 요청 성공
+     */
+    SUCCESS(true, "SUCCESS", "요청에 성공하였습니다."),
+
+    /**
+     * Request 오류
+     */
+    MISSING_VOTE_UUID(false, "MISSING_VOTE_UUID", "투표 ID가 누락되었습니다."),
+    NICKNAME_ALREADY_EXISTS_IN_VOTE(false, "NICKNAME_ALREADY_EXISTS_IN_VOTE", "해당 투표에서 이미 존재하는 닉네임입니다."),
+    VOTE_NOT_FOUND(false, "VOTE_NOT_FOUND", "존재하지 않는 투표입니다."),
+
+    GENERAL_ERROR(false, "GENERAL_ERROR", "알 수 없는 오류가 발생했습니다.")
+}

--- a/src/main/kotlin/com/goosesdream/golaping/common/enums/WebSocketResponseStatus.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/common/enums/WebSocketResponseStatus.kt
@@ -17,6 +17,8 @@ enum class WebSocketResponseStatus(
     MISSING_VOTE_UUID(false, "MISSING_VOTE_UUID", "투표 ID가 누락되었습니다."),
     NICKNAME_ALREADY_EXISTS_IN_VOTE(false, "NICKNAME_ALREADY_EXISTS_IN_VOTE", "해당 투표에서 이미 존재하는 닉네임입니다."),
     VOTE_NOT_FOUND(false, "VOTE_NOT_FOUND", "존재하지 않는 투표입니다."),
+    INVALID_VOTE_UUID(false, "INVALID_VOTE_UUID", "유효하지 않은 vote uuid입니다."),
+    EXPIRED_VOTE(false, "EXPIRED_VOTE", "종료된 투표입니다."),
 
     GENERAL_ERROR(false, "GENERAL_ERROR", "알 수 없는 오류가 발생했습니다.")
 }

--- a/src/main/kotlin/com/goosesdream/golaping/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/common/exception/GlobalExceptionHandler.kt
@@ -1,7 +1,7 @@
 package com.goosesdream.golaping.common.exception
 
 import com.goosesdream.golaping.common.base.BaseException
-import com.goosesdream.golaping.common.base.BaseResponseStatus
+import com.goosesdream.golaping.common.enums.BaseResponseStatus
 import org.hibernate.exception.ConstraintViolationException
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.http.ResponseEntity
@@ -13,12 +13,12 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
 
     @ExceptionHandler(ConstraintViolationException::class, DataIntegrityViolationException::class)
-    protected fun handleDataException(): ResponseEntity<ErrorResponse> {
-        return ErrorResponse.toResponseEntity(BaseResponseStatus.DUPLICATED_RESOURCE)
+    protected fun handleDataException(): ResponseEntity<HttpErrorResponse> {
+        return HttpErrorResponse.toResponseEntity(BaseResponseStatus.DUPLICATED_RESOURCE)
     }
 
     @ExceptionHandler(BaseException::class)
-    protected fun handleCustomException(e: BaseException): ResponseEntity<ErrorResponse> {
-        return ErrorResponse.toResponseEntity(e.status)
+    protected fun handleCustomException(e: BaseException): ResponseEntity<HttpErrorResponse> {
+        return HttpErrorResponse.toResponseEntity(e.status)
     }
 }

--- a/src/main/kotlin/com/goosesdream/golaping/common/exception/HttpErrorResponse.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/common/exception/HttpErrorResponse.kt
@@ -1,10 +1,10 @@
 package com.goosesdream.golaping.common.exception
 
-import com.goosesdream.golaping.common.base.BaseResponseStatus
+import com.goosesdream.golaping.common.enums.BaseResponseStatus
 import org.springframework.http.ResponseEntity
 import java.time.LocalDateTime
 
-data class ErrorResponse(
+data class HttpErrorResponse(
     val timestamp: LocalDateTime = LocalDateTime.now(),
     val status: Int,
     val error: String,
@@ -13,11 +13,20 @@ data class ErrorResponse(
 ) {
 
     companion object {
-        fun toResponseEntity(status: BaseResponseStatus): ResponseEntity<ErrorResponse> {
+        fun fromStatus(status: BaseResponseStatus): HttpErrorResponse {
+            return HttpErrorResponse(
+                status = status.httpStatus.value(),
+                error = status.httpStatus.name,
+                code = status.name,
+                message = status.message
+            )
+        }
+
+        fun toResponseEntity(status: BaseResponseStatus): ResponseEntity<HttpErrorResponse> {
             return ResponseEntity
                 .status(status.httpStatus)
                 .body(
-                    ErrorResponse(
+                    HttpErrorResponse(
                         status = status.httpStatus.value(),
                         error = status.httpStatus.name,
                         code = status.name,

--- a/src/main/kotlin/com/goosesdream/golaping/common/exception/WebSocketErrorResponse.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/common/exception/WebSocketErrorResponse.kt
@@ -1,0 +1,19 @@
+package com.goosesdream.golaping.common.exception
+
+import com.goosesdream.golaping.common.enums.WebSocketResponseStatus
+import java.time.LocalDateTime
+
+data class WebSocketErrorResponse(
+    val timestamp: LocalDateTime = LocalDateTime.now(),
+    val code: String,
+    val message: String
+) {
+    companion object {
+        fun fromStatus(status: WebSocketResponseStatus): WebSocketErrorResponse {
+            return WebSocketErrorResponse(
+                code = status.code,
+                message = status.message
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/goosesdream/golaping/common/websocket/GlobalWebSocketHandler.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/common/websocket/GlobalWebSocketHandler.kt
@@ -1,16 +1,19 @@
 package com.goosesdream.golaping.common.websocket
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.goosesdream.golaping.common.enums.WebSocketResponseStatus
+import com.goosesdream.golaping.common.enums.WebSocketResponseStatus.*
+import com.goosesdream.golaping.common.exception.WebSocketErrorResponse
+import com.goosesdream.golaping.common.websocket.dto.WebSocketInitialResponse
+import com.goosesdream.golaping.vote.service.VoteService
 import org.springframework.stereotype.Component
-import org.springframework.web.socket.CloseStatus
-import org.springframework.web.socket.WebSocketHandler
-import org.springframework.web.socket.WebSocketMessage
-import org.springframework.web.socket.WebSocketSession
+import org.springframework.web.socket.*
 
 @Component
 class GlobalWebSocketHandler(
     private val webSocketManager: WebSocketManager,
-    private val objectMapper: ObjectMapper
+    private val objectMapper: ObjectMapper,
+    private val voteService: VoteService
 ) : WebSocketHandler{
 
     override fun afterConnectionEstablished(session: WebSocketSession) { // WebSocket 연결 성립된 후 실행
@@ -20,6 +23,7 @@ class GlobalWebSocketHandler(
             val expirationTime = webSocketManager.getChannelExpirationTime(voteUuid)
 
             if (expirationTime == null || expirationTime <= System.currentTimeMillis()) { // 종료된 투표 또는 유효하지 않는 투표면
+                handleErrorResponse(session, EXPIRED_VOTE)
                 webSocketManager.stopWebSocketForVote(voteUuid)
                 return
             }
@@ -27,17 +31,43 @@ class GlobalWebSocketHandler(
             val remainingTimeMillis = expirationTime - System.currentTimeMillis()
 
             if (webSocketManager.restoreWebSocketSession(voteUuid) == null) { // 기존 세션이 없는 경우(첫 접속 유저) 타이머 설정 및 채널 초기화
-                webSocketManager.setWebSocketTimer(voteUuid, remainingTimeMillis)
-                webSocketManager.startWebSocketForVote(voteUuid, (remainingTimeMillis / 1000 / 60).toInt())
+                if (remainingTimeMillis > 0) {
+                    webSocketManager.setWebSocketTimer(voteUuid, remainingTimeMillis)
+                    webSocketManager.startWebSocketForVote(voteUuid, (remainingTimeMillis / 1000 / 60).toInt())
+                } else {
+                    handleErrorResponse(session, EXPIRED_VOTE)
+                    return
+                }
             }
 
             // 새로운 세션 저장
             webSocketManager.saveWebSocketSession(voteUuid, session)
+
+            val voteLimit = voteService.getVoteLimit(voteUuid)
+            val initialWebSocketResponse = WebSocketInitialResponse(
+                voteLimit = voteLimit,
+                voteEndTime = expirationTime
+            )
+            sendResponse(session, WebSocketResponse("연결에 성공했습니다.", initialWebSocketResponse))
+        } else {
+            handleErrorResponse(session, INVALID_VOTE_UUID)
+            return
         }
+    }
+
+    private fun sendResponse(session: WebSocketSession, response: Any) {
+        val jsonResponse = objectMapper.writeValueAsString(response)
+        session.sendMessage(TextMessage(jsonResponse))
+    }
+
+    private fun handleErrorResponse(session: WebSocketSession, errorStatus: WebSocketResponseStatus) {
+        sendResponse(session, WebSocketErrorResponse.fromStatus(errorStatus))
+        session.close()
     }
 
     override fun handleMessage(session: WebSocketSession, message: WebSocketMessage<*>) {
         println("Message received: ${message.payload}")
+        // TODO: Redis 세션이 없는 경우, 닉네임 기반으로 Vote 테이블에서 해당 유저의 기록을 조회해 복원
     }
 
     override fun handleTransportError(session: WebSocketSession, exception: Throwable) {

--- a/src/main/kotlin/com/goosesdream/golaping/common/websocket/WebSocketInterceptor.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/common/websocket/WebSocketInterceptor.kt
@@ -1,7 +1,7 @@
 package com.goosesdream.golaping.common.websocket
 
 import com.goosesdream.golaping.common.base.BaseException
-import com.goosesdream.golaping.common.base.BaseResponseStatus.*
+import com.goosesdream.golaping.common.enums.BaseResponseStatus.*
 import com.goosesdream.golaping.session.service.SessionService
 import com.goosesdream.golaping.vote.service.VoteService
 import org.springframework.http.server.ServerHttpRequest

--- a/src/main/kotlin/com/goosesdream/golaping/common/websocket/WebSocketManager.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/common/websocket/WebSocketManager.kt
@@ -1,6 +1,7 @@
 package com.goosesdream.golaping.common.websocket
 
 import com.goosesdream.golaping.redis.service.RedisService
+import com.goosesdream.golaping.session.service.SessionService
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.stereotype.Service
 import org.springframework.web.socket.WebSocketSession
@@ -53,13 +54,20 @@ class WebSocketManager(
 
     // 채널 종료
     fun stopWebSocketForVote(voteUuid: String) {
-        redisTemplate.delete(voteUuid)
+        redisService.delete(voteSessionPrefix + voteUuid)
 
         // 타이머 취소
         webSocketTimers[voteUuid]?.cancel()
         webSocketTimers.remove(voteUuid)
 
         // WebSocket 세션 종료
+        webSocketSessions[voteUuid]?.apply {
+            try {
+                close()
+            } catch (e: Exception) {
+                println("Failed to close WebSocket session: ${e.message}")
+            }
+        }
         webSocketSessions.remove(voteUuid)
     }
 

--- a/src/main/kotlin/com/goosesdream/golaping/common/websocket/WebSocketResponse.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/common/websocket/WebSocketResponse.kt
@@ -1,0 +1,28 @@
+package com.goosesdream.golaping.common.websocket
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonPropertyOrder
+import com.goosesdream.golaping.common.enums.WebSocketResponseStatus.*
+
+@JsonPropertyOrder("isSuccess", "message", "result")
+data class WebSocketResponse<T>(
+    @JsonProperty("isSuccess")
+    val isSuccess: Boolean,
+    val message: String,
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    val result: T? = null
+) {
+    constructor() : this(
+        isSuccess = true,
+        message = SUCCESS.message,
+        result = null
+    )
+
+    constructor(result: T) : this(
+        isSuccess = true,
+        message = SUCCESS.message,
+        result = result
+    )
+}

--- a/src/main/kotlin/com/goosesdream/golaping/common/websocket/WebSocketResponse.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/common/websocket/WebSocketResponse.kt
@@ -25,4 +25,10 @@ data class WebSocketResponse<T>(
         message = SUCCESS.message,
         result = result
     )
+
+    constructor(message: String, result: T) : this(
+        isSuccess = true,
+        message = message,
+        result = result
+    )
 }

--- a/src/main/kotlin/com/goosesdream/golaping/common/websocket/dto/WebSocketInitialResponse.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/common/websocket/dto/WebSocketInitialResponse.kt
@@ -1,0 +1,6 @@
+package com.goosesdream.golaping.common.websocket.dto
+
+data class WebSocketInitialResponse(
+    val voteLimit: Int,
+    val voteEndTime: Long
+)

--- a/src/main/kotlin/com/goosesdream/golaping/user/service/UserService.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/user/service/UserService.kt
@@ -6,7 +6,7 @@ import com.goosesdream.golaping.user.repository.UserRepository
 import com.goosesdream.golaping.vote.repository.VoteRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import com.goosesdream.golaping.common.base.BaseResponseStatus.*
+import com.goosesdream.golaping.common.enums.BaseResponseStatus.*
 import com.goosesdream.golaping.vote.entity.Participants
 import com.goosesdream.golaping.vote.entity.Votes
 import com.goosesdream.golaping.vote.repository.ParticipantRepository

--- a/src/main/kotlin/com/goosesdream/golaping/vote/controller/VoteController.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/vote/controller/VoteController.kt
@@ -48,7 +48,6 @@ class VoteController(
 
         val voteUuid = URI(voteRequest.link).path.split("/").last() // uuid 형식
 
-
         voteService.saveVoteExpirationToRedis(voteUuid, voteRequest.timeLimit)
         webSocketManager.startWebSocketForVote(voteUuid, voteRequest.timeLimit)
 
@@ -57,7 +56,7 @@ class VoteController(
         userService.addParticipant(creator, voteUuid)
 
         val websocketUrl = generateWebSocketUrl(voteUuid)
-        return BaseResponse(CreateVoteResponse(websocketUrl, sessionId))
+        return BaseResponse(CreateVoteResponse(websocketUrl, sessionId)) //TODO: sessionId 쿠키에 담아 반환하도록 수정
     }
 
     fun generateWebSocketUrl(voteUuid: String): String {

--- a/src/main/kotlin/com/goosesdream/golaping/vote/service/VoteService.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/vote/service/VoteService.kt
@@ -66,8 +66,7 @@ class VoteService(
 
     // 투표 종료 시간 조회
     fun getVoteEndTime(voteUuid: String): LocalDateTime? {
-        val vote = voteRepository.findByUuid(voteUuid)
-        return vote?.endTime
+        return voteRepository.findByUuid(voteUuid)?.endTime ?: throw BaseException(VOTE_NOT_FOUND)
     }
 
     private val voteExpirationPrefix = "vote:expiration:"
@@ -76,5 +75,9 @@ class VoteService(
         val redisKey = voteExpirationPrefix + voteUuid
         val ttlInSeconds = timeLimit * 60L
         redisService.save(redisKey, "active", ttlInSeconds)
+    }
+
+    fun getVoteLimit(voteUuid: String): Int {
+        return voteRepository.findByUuid(voteUuid)?.userVoteLimit ?: throw BaseException(VOTE_NOT_FOUND)
     }
 }

--- a/src/main/kotlin/com/goosesdream/golaping/vote/service/VoteService.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/vote/service/VoteService.kt
@@ -1,7 +1,7 @@
 package com.goosesdream.golaping.vote.service
 
 import com.goosesdream.golaping.common.base.BaseException
-import com.goosesdream.golaping.common.base.BaseResponseStatus.*
+import com.goosesdream.golaping.common.enums.BaseResponseStatus.*
 import com.goosesdream.golaping.common.enums.VoteType
 import com.goosesdream.golaping.redis.service.RedisService
 import com.goosesdream.golaping.user.entity.Users


### PR DESCRIPTION
## 🪁 관련 이슈
#61 

## ✨ 추가/수정/개선된 사항
- HTTP 기반 데이터 클래스 구조와 웹소켓 기반 데이터 클래스 구조를 분리
  - HTTP 기반의 BaseResponseStatus에서 웹소켓 응답을 위한 상태 enum을 분리
  - 웹소켓 응답을 위한 WebSocketResponse 데이터 클래스 구현
- 최초 연결 시 isSuccess, message, result(voteLimit, voteEndTime) 반환하도록 구현


## 📢 참고 사항

