### PR TITLE
[fix/112-webSocketHeader] convertAndSendToUser를 활용해 유저별로 응답을 수신하도록 수정

### DIFF
--- a/src/main/kotlin/com/goosesdream/golaping/websocket/configuration/WebSocketConfig.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/websocket/configuration/WebSocketConfig.kt
@@ -24,5 +24,6 @@ class WebSocketConfig(
     override fun configureMessageBroker(configurer: MessageBrokerRegistry) {
         configurer.enableSimpleBroker("/topic", "/queue") // 클라이언트가 구독할 경로
         configurer.setApplicationDestinationPrefixes("/app") // 클라이언트가 요청할 경로
+        configurer.setUserDestinationPrefix("/user") // 유저별로 메시지 전송
     }
 }

--- a/src/main/kotlin/com/goosesdream/golaping/websocket/controller/VoteWebSocketController.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/websocket/controller/VoteWebSocketController.kt
@@ -16,6 +16,7 @@ import com.goosesdream.golaping.vote.service.VoteService
 import org.springframework.messaging.handler.annotation.DestinationVariable
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler
 import org.springframework.messaging.handler.annotation.SendTo
+import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.messaging.simp.annotation.SendToUser
 import java.time.Instant
 import java.time.LocalDateTime
@@ -24,14 +25,18 @@ import java.time.ZoneId
 @Controller
 class VoteWebSocketController(
     private val webSocketManager: WebSocketManager,
-    private val voteService: VoteService) {
+    private val voteService: VoteService,
+    private val messagingTemplate: SimpMessagingTemplate
+) {
 
     // WebSocket 연결 후 실행
-    @MessageMapping("/vote/{voteUuid}/connect")
-    @SendToUser("/queue/initialResponse")
+    @MessageMapping("/vote/connect")
     fun connectToVote(
-        @DestinationVariable voteUuid: String,
-        session: SimpMessageHeaderAccessor): WebSocketResponse<Any> {
+        headers: SimpMessageHeaderAccessor): WebSocketResponse<Any> {
+        val voteUuid = headers.sessionAttributes?.get("voteUuid") as? String ?: throw IllegalStateException("MISSING_VOTE_UUID")
+        val nickname = headers.sessionAttributes?.get("nickname") as? String ?: throw IllegalStateException("MISSING_NICKNAME")
+        val sessionId = headers.sessionAttributes?.get("sessionId") as? String ?: throw IllegalStateException("MISSING_SESSION_ID")
+
         val expirationTime = webSocketManager.getChannelExpirationTime(voteUuid) ?: throw IllegalStateException("EXPIRED_VOTE")
         val expirationDateTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(expirationTime), ZoneId.of("Asia/Seoul"))
 
@@ -45,10 +50,7 @@ class VoteWebSocketController(
         webSocketManager.setWebSocketTimer(voteUuid, remainingTimeMillis)
         webSocketManager.startWebSocketForVote(voteUuid, (remainingTimeMillis / 1000 / 60).toInt())
 
-        val nickname = session.sessionAttributes?.get("nickname") as? String
-            ?: throw IllegalStateException("MISSING_NICKNAME")
-
-        val webSocketSessionId = session.sessionId ?: throw IllegalStateException("MISSING_WEBSOCKET_SESSION_ID")
+        val webSocketSessionId = headers.sessionId ?: throw IllegalStateException("MISSING_WEBSOCKET_SESSION_ID")
         webSocketManager.saveWebSocketSession(voteUuid, webSocketSessionId)
 
         val voteLimit = voteService.getVoteLimit(voteUuid)
@@ -60,17 +62,20 @@ class VoteWebSocketController(
             webSocketSessionId,
             previousVotes
         )
+
+        messagingTemplate.convertAndSendToUser(sessionId, "/queue/initialResponse", initialWebSocketResponse)
+
         return WebSocketResponse("연결에 성공했습니다.", initialWebSocketResponse)
     }
 
     // 투표 옵션 추가
-    @MessageMapping("/vote/{voteUuid}/addOption")
+    @MessageMapping("/vote/addOption")
     @SendTo("/topic/vote/{voteUuid}/addOption")
     fun handleAddOption(
-        @DestinationVariable voteUuid: String,
         headers: SimpMessageHeaderAccessor,
         message: AddVoteOptionRequest
     ): WebSocketResponse<Any> {
+        val voteUuid = headers.sessionAttributes?.get("voteUuid") as? String ?: throw IllegalStateException("MISSING_VOTE_UUID")
         val nickname = headers.sessionAttributes?.get("nickname") as? String ?: throw IllegalArgumentException("MISSING_NICKNAME")
 
         val newOption = voteService.addOption(voteUuid, nickname, message.optionText, message.optionColor)
@@ -78,14 +83,15 @@ class VoteWebSocketController(
     }
 
     // 투표/투표취소
-    @MessageMapping("/vote/{voteUuid}")
+    @MessageMapping("/vote")
     @SendTo("/topic/vote/{voteUuid}")
     fun handleVoteToggle(
-        @DestinationVariable voteUuid: String,
         headers: SimpMessageHeaderAccessor,
         message: VoteRequest
     ): WebSocketResponse<Any> {
+        val voteUuid = headers.sessionAttributes?.get("voteUuid") as? String ?: throw IllegalStateException("MISSING_VOTE_UUID")
         val nickname = headers.sessionAttributes?.get("nickname") as? String ?: throw IllegalArgumentException("MISSING_NICKNAME")
+
         val selectedOptionId = message.optionId ?: throw IllegalArgumentException("MISSING_SELECTED_OPTION")
 
         val vote = voteService.getVote(voteUuid) ?: throw IllegalStateException("VOTE_NOT_FOUND")
@@ -122,13 +128,14 @@ class VoteWebSocketController(
     }
 
     // [생성자] 투표 제한 시간 도달 전 미리 투표 종료
-    @MessageMapping("/vote/{voteUuid}/close")
+    @MessageMapping("/vote/close")
     @SendTo("/topic/vote/{voteUuid}/closed")
     fun closeVote(
-        @DestinationVariable voteUuid: String,
         headers: SimpMessageHeaderAccessor): WebSocketResponse<Any> {
-        val vote = voteService.getVote(voteUuid) ?: throw IllegalStateException("VOTE_NOT_FOUND")
+        val voteUuid = headers.sessionAttributes?.get("voteUuid") as? String ?: throw IllegalStateException("MISSING_VOTE_UUID")
         val nickname = headers.sessionAttributes?.get("nickname") as? String ?: throw IllegalArgumentException("MISSING_NICKNAME")
+
+        val vote = voteService.getVote(voteUuid) ?: throw IllegalStateException("VOTE_NOT_FOUND")
 
         val voteResults = voteService.closeVote(vote, nickname)
         webSocketManager.stopWebSocketForVote(voteUuid)
@@ -158,6 +165,7 @@ class VoteWebSocketController(
                     "EXPIRED_VOTE" -> WebSocketErrorResponse.fromStatus(EXPIRED_VOTE)
                     "MISSING_WEBSOCKET_SESSION_ID" -> WebSocketErrorResponse.fromStatus(MISSING_WEBSOCKET_SESSION_ID)
                     "MISSING_NICKNAME" -> WebSocketErrorResponse.fromStatus(MISSING_NICKNAME)
+                    "MISSING_VOTE_UUID" -> WebSocketErrorResponse.fromStatus(MISSING_VOTE_UUID)
                     "VOTE_NOT_FOUND" -> WebSocketErrorResponse.fromStatus(VOTE_NOT_FOUND)
                     "VOTE_OPTION_NOT_FOUND" -> WebSocketErrorResponse.fromStatus(VOTE_OPTION_NOT_FOUND)
                     "USER_VOTE_LIMIT_EXCEEDED" -> WebSocketErrorResponse.fromStatus(USER_VOTE_LIMIT_EXCEEDED)


### PR DESCRIPTION
## 🪁 관련 이슈
#112

## ✨ 추가/수정/개선된 사항
- config에 userDestinaitonPrefix 추가
- convertAndSendToUser를 활용해 sessionId를 기준으로 유저별 응답 전송 구현
- 웹소켓 연결 종료 시 클라이언트가 연결 종료 메세지를 받을 수 있도록 구현

## 📢 참고 사항

