### PR TITLE
[fix/119-webSocketInterceptor] null이거나 유효하지 않은 값에 대해 예외 처리

### DIFF
--- a/src/main/kotlin/com/goosesdream/golaping/common/enums/BaseResponseStatus.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/common/enums/BaseResponseStatus.kt
@@ -28,9 +28,9 @@ enum class BaseResponseStatus(
     // vote
     INVALID_VOTE_TYPE(false, HttpStatus.BAD_REQUEST, "투표 타입이 올바르지 않습니다."),
     INVALID_TIME_LIMIT(false, HttpStatus.BAD_REQUEST, "투표 제한 시간은 0분보다 커야합니다."),
-    ALREADY_EXIST_CHANNEL(false, HttpStatus.CONFLICT, "이미 존재하는 채널입니다."),
     VOTE_NOT_FOUND(false, HttpStatus.BAD_REQUEST, "존재하지 않는 투표입니다."),
     EXPIRED_VOTE(false, HttpStatus.BAD_REQUEST, "만료된 투표입니다."),
+    MISSING_VOTE_UUID(false, HttpStatus.BAD_REQUEST, "voteUuid가 없습니다."),
 
     // vote option
     INVALID_OPTION_TEXT(false, HttpStatus.BAD_REQUEST, "유효하지 않은 option text 입니다."),

--- a/src/main/kotlin/com/goosesdream/golaping/websocket/interceptor/WebSocketInterceptor.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/websocket/interceptor/WebSocketInterceptor.kt
@@ -26,26 +26,23 @@ class WebSocketInterceptor(
         wsHandler: WebSocketHandler,
         attributes: MutableMap<String, Any?>
     ): Boolean {
-        // 쿠키에서 sessionId 추출
         val cookies = (request as? ServletServerHttpRequest)?.servletRequest?.cookies
         val sessionId = cookies?.firstOrNull { it.name == "SESSIONID" }?.value
+        if (sessionId.isNullOrBlank()) throw BaseException(MISSING_SESSION_ID)
 
         val voteUuid = request.headers["voteUuid"]?.firstOrNull()
-        attributes["voteUuid"] = if (!voteUuid.isNullOrBlank() && isValidVoteUuid(voteUuid)) {
-            voteUuid
-        } else {
-            ""
-        } // TODO: 예외처리 원복
+        if (voteUuid.isNullOrBlank() || !isValidVoteUuid(voteUuid)) throw BaseException(MISSING_VOTE_UUID)
 
-        val isVoteEnded = if (voteUuid != null) voteService.checkVoteEnded(voteUuid) else true
+        val isVoteEnded = voteService.checkVoteEnded(voteUuid)
         val nickname = if (!isVoteEnded) {
-            sessionId?.let {
+            sessionId.let {
                 sessionService.getNicknameFromSession(it) ?: throw BaseException(UNAUTHORIZED)
-            } ?: throw BaseException(MISSING_SESSION_ID)
+            }
         } else null
 
-        attributes["sessionId"] = sessionId ?: ""
-        attributes["nickname"] = nickname ?: ""
+        attributes["sessionId"] = sessionId
+        attributes["voteUuid"] = voteUuid
+        attributes["nickname"] = nickname
         attributes["isVoteEnded"] = isVoteEnded
 
         return true

--- a/src/main/kotlin/com/goosesdream/golaping/websocket/interceptor/WebSocketInterceptor.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/websocket/interceptor/WebSocketInterceptor.kt
@@ -35,7 +35,7 @@ class WebSocketInterceptor(
             voteUuid
         } else {
             ""
-        }
+        } // TODO: 예외처리 원복
 
         val isVoteEnded = if (voteUuid != null) voteService.checkVoteEnded(voteUuid) else true
         val nickname = if (!isVoteEnded) {


### PR DESCRIPTION
## 🪁 관련 이슈
#119 

## ✨ 추가/수정/개선된 사항
- 프론트 로직 수정으로 nickname, sessionId, voteUuid가 null로 들어올 가능성이 없어짐
- 따라서, WebSocketInterceptor에서 nickname, sessionId, voteUuid에 대해 null이거나 유효하지 않은 값일 경우 예외 처리 

## 📢 참고 사항

