### PR TITLE
[fix/121-principal] Principal 객체를 이용해 유저를 식별할 수 없는 문제 해결

### DIFF
--- a/src/main/kotlin/com/goosesdream/golaping/common/enums/WebSocketResponseStatus.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/common/enums/WebSocketResponseStatus.kt
@@ -26,6 +26,7 @@ enum class WebSocketResponseStatus(
 
     // websocket session
     MISSING_WEBSOCKET_SESSION_ID(false, "MISSING_WEBSOCKET_SESSION_ID", "웹소켓 세션 ID가 누락되었습니다."),
+    MISSING_PRINCIPAL(false, "MISSING_PRINCIPAL", "유저를 식별하는 Principal 구현체가 없습니다."),
 
     // vote option
     MISSING_SELECTED_OPTION(false, "MISSING_SELECTED_OPTION", "선택된 옵션이 누락되었습니다."),

--- a/src/main/kotlin/com/goosesdream/golaping/websocket/configuration/WebSocketConfig.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/websocket/configuration/WebSocketConfig.kt
@@ -1,5 +1,6 @@
 package com.goosesdream.golaping.websocket.configuration
 
+import com.goosesdream.golaping.websocket.handler.CustomHandshakeHandler
 import com.goosesdream.golaping.websocket.interceptor.WebSocketInterceptor
 import org.springframework.context.annotation.Configuration
 import org.springframework.messaging.simp.config.MessageBrokerRegistry
@@ -8,7 +9,8 @@ import org.springframework.web.socket.config.annotation.*
 @Configuration
 @EnableWebSocketMessageBroker
 class WebSocketConfig(
-    private val webSocketInterceptor: WebSocketInterceptor
+    private val webSocketInterceptor: WebSocketInterceptor,
+    private val customHandshakeHandler: CustomHandshakeHandler
 ): WebSocketMessageBrokerConfigurer {
     override fun registerStompEndpoints(registry: StompEndpointRegistry) {
         registry.addEndpoint("/ws/votes")
@@ -17,6 +19,7 @@ class WebSocketConfig(
                 "http://localhost:8080",
                 "http://golping.site"
             )
+            .setHandshakeHandler(customHandshakeHandler)
             .addInterceptors(webSocketInterceptor)
             .withSockJS()
     }

--- a/src/main/kotlin/com/goosesdream/golaping/websocket/handler/CustomHandshakeHandler.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/websocket/handler/CustomHandshakeHandler.kt
@@ -1,0 +1,36 @@
+package com.goosesdream.golaping.websocket.handler
+
+import com.goosesdream.golaping.common.base.BaseException
+import com.goosesdream.golaping.common.enums.BaseResponseStatus.MISSING_SESSION_ID
+import org.springframework.http.server.ServerHttpRequest
+import org.springframework.http.server.ServletServerHttpRequest
+import org.springframework.stereotype.Component
+import org.springframework.web.socket.WebSocketHandler
+import org.springframework.web.socket.server.support.DefaultHandshakeHandler
+import java.security.Principal
+
+@Component
+class CustomHandshakeHandler : DefaultHandshakeHandler() {
+
+    override fun determineUser(
+        request: ServerHttpRequest,
+        wsHandler: WebSocketHandler,
+        attributes: MutableMap<String, Any>
+    ): Principal {
+
+        // 쿠키에서 sessionId 추출, 쿠키가 없으면 웹소켓 연결 거부
+        val cookies = (request as? ServletServerHttpRequest)?.servletRequest?.cookies
+        val sessionId = cookies?.firstOrNull { it.name == "SESSIONID" }?.value
+            ?.takeIf { it.isNotBlank() }
+            ?: throw BaseException(MISSING_SESSION_ID)
+
+        return StompPrincipal(sessionId)
+    }
+}
+
+// Principal 구현체
+data class StompPrincipal(
+    private val name: String
+) : Principal {
+    override fun getName(): String = name
+}

--- a/src/main/kotlin/com/goosesdream/golaping/websocket/handler/GlobalWebSocketHandler.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/websocket/handler/GlobalWebSocketHandler.kt
@@ -1,4 +1,4 @@
-package com.goosesdream.golaping.websocket
+package com.goosesdream.golaping.websocket.handler
 
 //@Component
 //class GlobalWebSocketHandler(

--- a/src/main/kotlin/com/goosesdream/golaping/websocket/interceptor/WebSocketInterceptor.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/websocket/interceptor/WebSocketInterceptor.kt
@@ -28,7 +28,8 @@ class WebSocketInterceptor(
     ): Boolean {
         val cookies = (request as? ServletServerHttpRequest)?.servletRequest?.cookies
         val sessionId = cookies?.firstOrNull { it.name == "SESSIONID" }?.value
-        if (sessionId.isNullOrBlank()) throw BaseException(MISSING_SESSION_ID)
+            ?.takeIf { it.isNotBlank() }
+            ?: throw BaseException(MISSING_SESSION_ID)
 
         val voteUuid = request.headers["voteUuid"]?.firstOrNull()
         if (voteUuid.isNullOrBlank() || !isValidVoteUuid(voteUuid)) throw BaseException(MISSING_VOTE_UUID)


### PR DESCRIPTION
## 🪁 관련 이슈
#121

## ✨ 추가/수정/개선된 사항
- CustomHandshakeHandler 구현
- WebSocketConfig에 CustomHanshakeHandler 추가 등록
- sessionId를 웹소켓 세션이 아닌 principal 객체에서 추출하도록 수정

## 📢 참고 사항

