### PR TITLE
[fix/124-webSocketInterceptor] Interceptor에서 http 헤더가 아닌 쿠키에서 값을 조회하도록 수정

### DIFF
--- a/src/main/kotlin/com/goosesdream/golaping/common/enums/BaseResponseStatus.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/common/enums/BaseResponseStatus.kt
@@ -39,7 +39,7 @@ enum class BaseResponseStatus(
 
     // session
     INVALID_SESSION(false, HttpStatus.BAD_REQUEST, "유효하지 않은 세션입니다."),
-    UNAUTHORIZED(false, HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
+    UNAUTHORIZED(false, HttpStatus.UNAUTHORIZED, "닉네임 입력을 먼저 수행해야 합니다."),
     INVALID_VOTE_UUID(false, HttpStatus.BAD_REQUEST, "유효하지 않은 vote uuid 입니다."),
     MISSING_SESSION_ID(false, HttpStatus.BAD_REQUEST, "세션 ID가 없습니다."),
 

--- a/src/main/kotlin/com/goosesdream/golaping/vote/controller/VoteController.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/vote/controller/VoteController.kt
@@ -95,7 +95,7 @@ class VoteController(
         timeLimit: Int,
         response: HttpServletResponse
     ) {
-        val cookie = Cookie("SESSIONID", sessionId).apply { // TODO: https 설정 후 secure 속성 추가
+        val cookie = Cookie("sessionId", sessionId).apply { // TODO: https 설정 후 secure 속성 추가
             isHttpOnly = true
             path = "/"
             maxAge = timeLimit * 60
@@ -104,7 +104,7 @@ class VoteController(
 
     //  response.setHeader( // TODO: https 설정 후 헤더 설정 추가
     //      "Set-Cookie",
-    //      "SESSIONID=$sessionId; Path=/; Max-Age=${timeLimit * 60}; HttpOnly; SameSite=None; Secure"
+    //      "sessionId=$sessionId; Path=/; Max-Age=${timeLimit * 60}; HttpOnly; SameSite=None; Secure"
     //  )
     }
 

--- a/src/main/kotlin/com/goosesdream/golaping/websocket/handler/CustomHandshakeHandler.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/websocket/handler/CustomHandshakeHandler.kt
@@ -20,7 +20,7 @@ class CustomHandshakeHandler : DefaultHandshakeHandler() {
 
         // 쿠키에서 sessionId 추출, 쿠키가 없으면 웹소켓 연결 거부
         val cookies = (request as? ServletServerHttpRequest)?.servletRequest?.cookies
-        val sessionId = cookies?.firstOrNull { it.name == "SESSIONID" }?.value
+        val sessionId = cookies?.firstOrNull { it.name == "sessionId" }?.value
             ?.takeIf { it.isNotBlank() }
             ?: throw BaseException(MISSING_SESSION_ID)
 

--- a/src/test/kotlin/com/goosesdream/golaping/vote/VoteControllerTest.kt
+++ b/src/test/kotlin/com/goosesdream/golaping/vote/VoteControllerTest.kt
@@ -89,7 +89,7 @@ class VoteControllerTest {
 
         val cookieHeader = result.response.getHeader("Set-Cookie")
         assertThat(cookieHeader).isNotNull()
-        assertThat(cookieHeader).contains("SESSIONID=")
+        assertThat(cookieHeader).contains("sessionId=")
         assertThat(cookieHeader).contains("Path=/")
         assertThat(cookieHeader).contains("HttpOnly")
         assertThat(cookieHeader).contains("Max-Age=${voteRequest.timeLimit * 60}")


### PR DESCRIPTION
## 🪁 관련 이슈
#124

## ✨ 추가/수정/개선된 사항
```
- 기존에 Http 헤더에서 조회하던 voteUuid 값을 쿠키에서 조회하도록 방식 수정
  - 핸드쉐이크 단계에서 헤더 커스텀이 불가능하기 때문에 url 파라미터나 쿠키로 전달해야 하는데, 보안을 고려해 쿠키로 전달받도록 수정  
```

## 📢 참고 사항
- 쿠키로 전달 받는 값에서 nickname 제외
