### PR TITLE
[fix/126-corsFilter] WebConfig 대신 CorsConfig를 정의해 CorsFilter를 사용

### DIFF
--- a/src/main/kotlin/com/goosesdream/golaping/common/util/LoggerUtil.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/common/util/LoggerUtil.kt
@@ -1,0 +1,12 @@
+package com.goosesdream.golaping.common.util
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+inline fun <reified T> T.logger(): Logger {
+    return if (T::class.isCompanion) {
+        LoggerFactory.getLogger(T::class.java.enclosingClass)
+    } else {
+        LoggerFactory.getLogger(T::class.java)
+    }
+}

--- a/src/main/kotlin/com/goosesdream/golaping/configuration/CorsConfig.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/configuration/CorsConfig.kt
@@ -1,0 +1,24 @@
+package com.goosesdream.golaping.configuration
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource
+import org.springframework.web.filter.CorsFilter
+
+@Configuration
+class CorsConfig {
+    @Bean
+    fun corsFilter(): CorsFilter {
+        val source = UrlBasedCorsConfigurationSource()
+        val config = CorsConfiguration()
+
+        config.allowedOriginPatterns = listOf("http://localhost:3300", "http://golaping.site")
+        config.allowedMethods = listOf("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+        config.allowedHeaders = listOf("*")
+        config.allowCredentials = true
+
+        source.registerCorsConfiguration("/**", config)
+        return CorsFilter(source)
+    }
+}

--- a/src/main/kotlin/com/goosesdream/golaping/configuration/WebConfig.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/configuration/WebConfig.kt
@@ -4,13 +4,13 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.web.servlet.config.annotation.CorsRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
-@Configuration
-class WebConfig : WebMvcConfigurer {
-    override fun addCorsMappings(registry: CorsRegistry) {
-        registry.addMapping("/**")
-            .allowedOrigins("http://localhost:3300", "http://golaping.site")
-            .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
-            .allowedHeaders("*")
-            .allowCredentials(true) // 쿠키
-    }
-}
+//@Configuration
+//class WebConfig : WebMvcConfigurer {
+//    override fun addCorsMappings(registry: CorsRegistry) {
+//        registry.addMapping("/**")
+//            .allowedOrigins("http://localhost:3300", "http://golaping.site")
+//            .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+//            .allowedHeaders("*")
+//            .allowCredentials(true) // 쿠키
+//    }
+//}

--- a/src/main/kotlin/com/goosesdream/golaping/websocket/configuration/WebSocketConfig.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/websocket/configuration/WebSocketConfig.kt
@@ -14,12 +14,13 @@ class WebSocketConfig(
 ): WebSocketMessageBrokerConfigurer {
     override fun registerStompEndpoints(registry: StompEndpointRegistry) {
         registry.addEndpoint("/ws/votes")
-            .setAllowedOrigins(
+            .setAllowedOriginPatterns(
                 "http://localhost:3300",
                 "http://localhost:8080",
                 "http://golping.site"
             )
             .setHandshakeHandler(customHandshakeHandler)
+            .setAllowedOrigins()
             .addInterceptors(webSocketInterceptor)
             .withSockJS()
     }

--- a/src/main/kotlin/com/goosesdream/golaping/websocket/interceptor/WebSocketInterceptor.kt
+++ b/src/main/kotlin/com/goosesdream/golaping/websocket/interceptor/WebSocketInterceptor.kt
@@ -2,6 +2,7 @@ package com.goosesdream.golaping.websocket.interceptor
 
 import com.goosesdream.golaping.common.base.BaseException
 import com.goosesdream.golaping.common.enums.BaseResponseStatus.*
+import com.goosesdream.golaping.common.util.logger
 import com.goosesdream.golaping.session.service.SessionService
 import com.goosesdream.golaping.vote.service.VoteService
 import org.springframework.http.server.ServerHttpRequest
@@ -20,6 +21,8 @@ class WebSocketInterceptor(
     private val sessionService: SessionService,
     private val voteService: VoteService) : HandshakeInterceptor {
 
+    private val log = logger()
+
     override fun beforeHandshake( // WebSocket 연결 전 실행되는 HTTP 요청
         request: ServerHttpRequest,
         response: ServerHttpResponse,
@@ -28,13 +31,25 @@ class WebSocketInterceptor(
     ): Boolean {
         val cookies = (request as? ServletServerHttpRequest)?.servletRequest?.cookies
 
+        if (cookies == null) {
+            log.error("No cookies found in the request")
+        } else {
+            log.info("Received Cookies: ${cookies.joinToString { "${it.name}=${it.value}" }}")
+        }
+
         val sessionId = cookies?.firstOrNull { it.name == "sessionId" }?.value
             ?.takeIf { it.isNotBlank() }
-            ?: throw BaseException(MISSING_SESSION_ID)
+            ?: run {
+                log.error("Missing sessionId cookie")
+                throw BaseException(MISSING_SESSION_ID)
+            }
 
         val voteUuid = cookies.firstOrNull { it.name == "voteUuid" }?.value
             ?.takeIf { it.isNotBlank() && isValidVoteUuid(it) }
-            ?: throw BaseException(MISSING_VOTE_UUID)
+            ?: run {
+                log.error("Missing or invalid voteUuid cookie")
+                throw BaseException(MISSING_VOTE_UUID)
+            }
 
         val isVoteEnded = voteService.checkVoteEnded(voteUuid)
 


### PR DESCRIPTION
## 🪁 관련 이슈
#126

## ✨ 추가/수정/개선된 사항
```
- CorsFilter를 구현한 CorsConfig로 대체
- setAllowedOriginPatterns를 사용해 허용 url 패턴 다양성 추구
- 로깅을 위해 LoggerUtil 추가
- Interceptor에 다양한 로그 추가
```

## 📢 참고 사항

